### PR TITLE
hybrid encrypted/decrypted support + fields not to encrypt

### DIFF
--- a/lib/box.js
+++ b/lib/box.js
@@ -3,8 +3,16 @@ var pick = require('lodash/object/pick')
 var omit = require('lodash/object/omit')
 var assign = require('lodash/object/assign')
 
-function underscoreProperties(_, key) {
-  return key[0] === '_'
+function createOmitList(doc){
+  var omitList = ["encrypt", "dontencrypt"];
+
+  Object.keys(doc).forEach(function(key){
+    if(key[0] === '_') omitList.push(key);
+    if(doc.dontencrypt && doc.dontencrypt.indexOf(key) != -1) omitList.push(key);
+  });
+
+  return omitList;
+
 }
 
 module.exports = function box(databaseKey, receivers) {
@@ -19,6 +27,7 @@ module.exports = function box(databaseKey, receivers) {
   var box = function(doc) {
     if (turnedOff) return doc
     if (doc._id.match(/^permit\//)) return doc
+    if (!doc.encrypt) return doc
 
     var key = nacl.randomBytes(nacl.secretbox.keyLength)
     var nonce = nacl.randomBytes(nacl.secretbox.nonceLength)
@@ -47,7 +56,7 @@ module.exports = function box(databaseKey, receivers) {
     }, {})
 
     var box = nacl.util.encodeBase64(nacl.secretbox(
-      nacl.util.decodeUTF8(JSON.stringify(omit(doc, underscoreProperties))),
+      nacl.util.decodeUTF8(JSON.stringify(omit(doc, createOmitList(doc)))),
       nonce,
       key
     ))
@@ -58,7 +67,7 @@ module.exports = function box(databaseKey, receivers) {
         receivers: recs,
         box: box
       },
-      pick(doc, underscoreProperties))
+      pick(doc, createOmitList(doc)))
   }
 
 
@@ -68,6 +77,7 @@ module.exports = function box(databaseKey, receivers) {
     if (doc._id.match(/^permit\//)) return doc
     if (doc._id.match(/^_design\//)) return doc
     if (!(sender in doc.receivers)) return doc
+    if (!doc.encrypt) return doc
 
     var permit = doc.receivers[sender]
     var key = nacl.box.open(
@@ -92,7 +102,7 @@ module.exports = function box(databaseKey, receivers) {
       }, {})
 
     return assign(JSON.parse(nacl.util.encodeUTF8(data)),
-      pick(doc, underscoreProperties), {
+      pick(doc, createOmitList(doc)), {
         receivers: recs
       })
   }


### PR DESCRIPTION
Added hybrid encrypted/non encrypted doc support. docs _require_ an encrypt=true property to be encrypted.

Added dontencrypt flag to doc. By default these two flags will be omitted, and any extras listed in dontencrypt will too.

example: 
doc = {  "_id": "test", "tags": ["thing", "or", "two"], "security": { "readers": "blah" }, "content": "moo", "encrypt": true, "dontencrypt": ["tags", "security"]  }

encrypted_doc = {  "_id": "test", "tags": ["thing", "or", "two"], "security": { "readers": "blah" }, "box": "AZE43R5G4356", "encrypt": true, "dontencrypt": ["tags", "security"], + encryption fields }

Feel free to move things around, or make 'em fancier :)
